### PR TITLE
Paper: Expand abbreviations in headings

### DIFF
--- a/paper/content/analyse.tex
+++ b/paper/content/analyse.tex
@@ -79,7 +79,7 @@ werden.
 Für den hier vorgestellten Anwendungsfall ist dieser Ansatz jedoch nicht geeignet, da im gesamten
 Gebäude Sensoren verteilt werden müssen, um eine lückenlose Positionierung gewährleisten zu können.
 
-\subsection{Lokalisierung durch \gls{WLAN}-Netzwerke}
+\subsection{Lokalisierung durch \glsentryshort{WLAN}-Netzwerke}
 
 Eine weitere Möglichkeit ist, auf bestehende Infrastruktur zurückzugreifen. \Gls{WLAN} ist
 heutzutage in praktisch jedem Gebäude verfügbar.

--- a/paper/content/entwurf.tex
+++ b/paper/content/entwurf.tex
@@ -39,7 +39,7 @@ In den folgenden Abschnitten wird detaillierter auf die einzelnen Komponenten de
 Dabei werden die Komponenten in derselben Reihenfolge beschrieben, in welcher die Daten im
 Gesamtsystem fließen.
 
-\subsection{Tracking mit IoT-Hardware} \label{sec:tracking-hardware}
+\subsection{Tracking mit \glsentrylong{IoT}-Hardware} \label{sec:tracking-hardware}
 
 Zur Erfassung der Standortdaten der Dokumente werden, wie in \autoref{sec:soll-analyse}
 beschrieben, Hardware-Tracker eingesetzt.

--- a/paper/content/grundlagen.tex
+++ b/paper/content/grundlagen.tex
@@ -6,7 +6,7 @@ Das Projekt wird im Umfeld der \gls{DHBW} Karlsruhe im Rahmen einer Studienarbei
 Ziel der Studienarbeit ist es, ein praktisches Projekt zu entwickeln und dies entsprechend zu dokumentieren.
 Der Zeitrahmen für dieses Projekt und die Studienarbeit beläuft sich auf ein halbes Jahr.
 
-\section{Funktionsweise \gls{WLAN}} \label{sec:grundlagen-wlan}
+\section{Funktionsweise \glsentryfull{WLAN}} \label{sec:grundlagen-wlan}
 
 Unter \gls{WLAN} versteht man im Allgemeinen ein Funknetz nach einem Standard der \gls{IEEE} 802.11 Familie.
 Alle Standards der Familie basieren auf dem ursprünglichen 802.11 Standard und erweitern diesen um neue Funktionalität, Frequenzen und höheren Datenraten.
@@ -17,7 +17,7 @@ Für die Funktionsweise des Paper-Trackers muss der Teil der \enquote{Service Se
 Unter einem Service Set versteht man im Allgemeinen alle Geräte in einem \gls{WLAN}-Netzwerk.
 Auf diesen basiert die Lokalisierung der Dokumente.
 
-\subsection{\gls{BSS}}
+\subsection{\glsentryfull{BSS}}
 
 Ein \gls{BSS} ist Service Set, in dem es nur einen \gls{AP} und damit ein Gerät, dass das Funknetz aufbaut, gibt.
 Zu diesem \gls{AP} können beliebig viele Klienten verbunden sein.
@@ -29,7 +29,7 @@ Diese ist meist die \gls{MAC}-Adresse des \gls{AP}, welche per Definition einzig
 \TODO{Primärquelle finden (IEEE RFC)}
 Mit Hilfe dieser \gls{BSSID} können Klienten zwischen den verschiedenen Netzwerken mit identischer \gls{SSID} unterscheiden.
 
-\subsection{\gls{ESS}}
+\subsection{\glsentryfull{ESS}}
 
 In einem \gls{ESS} existieren mehrere \gls{BSS}, die miteinander z.B. über ein \gls{LAN} verbunden sind.
 Alle \gls{BSS} in diesem Service Set haben eine eigene \gls{BSSID} aber bauen ein Netz mit der gleichen \gls{SSID} auf.
@@ -37,7 +37,7 @@ So können Klienten z.B. in größeren Gebäuden zwischen verschiedenen \gls{BSS
 (vgl. \cite{Haider2019})
 \TODO{Primärquelle finden}
 
-\subsection{Signalstärke \gls{RSSI}}
+\subsection{\glsentryfull{RSSI}}
 
 Die \gls{RSSI} ist eine Größe, welche im Allgemeinen die Energie eines Radiosignals repräsentiert.
 Es gibt keine Standardisierung hinsichtlich der Messmethode oder der entstehenden Einheit, in

--- a/paper/content/implementierung.tex
+++ b/paper/content/implementierung.tex
@@ -167,7 +167,7 @@ In einem späteren Einsatz des Paper-Trackers kann dank der \enquote{gorm} Bibli
 Möglich sind dafür \enquote{MySQL}, \enquote{PostgreSQL}, \enquote{Microsoft SQL Server} und wie erwähnt SQLite.
 Im Code des Servers muss hierfür lediglich eine erweiterte Konfiguration ermöglicht werden. (vgl. \cite{Jinzhu2020})
 
-\subsection{REST-Schnittstelle}
+\subsection{\glsentryfull{REST}-Schnittstelle}
 
 Die \gls{REST}-Schnittstelle zur Anbindung der App wurde wie in \autoref{par:app-schnittstelle}
 beschrieben implementiert.
@@ -182,7 +182,7 @@ Manager-Funktionen aufgerufen, welche die Geschäftslogik enthalten. Das Ergebni
 wird dann von der Handler-Funktion in das Zielformat, in diesem Fall \gls{JSON}, serialisiert und an
 den Aufrufer gesendet.
 
-\subsection{CoAP-Schnittstelle}
+\subsection{\glsentryfull{CoAP}-Schnittstelle}
 
 Die \gls{CoAP}-Schnittstelle für die Tracker wurde grundsätzlich wie in
 \autoref{par:tracker-schnittstelle} beschrieben implementiert. Es wurde allerdings ein weiterer
@@ -724,7 +724,7 @@ Es konnte zwar eine funktionierende und fast vollständige Lösung implementiert
 Herausforderungen beinhaltet.
 Dies sind mehrere Anpassungen oder Fehler, die aufgrund der begrenzten Projektzeit nicht angegangen werden konnten.
 
-\subsection{\gls{UI}-Details in der App}
+\subsection{\glsentrylong{UI}-Details in der App}
 
 Innerhalb der App für den Paper-Tracker gibt es eine fehlende Funktion, die noch nicht implementiert wurde.
 Dies ist die Unterstützung für mehrere Räume pro Schritt in einem Workflow Template.


### PR DESCRIPTION
Abbreviations used in headings now also don't count as 'used', so their
next occurance will still use the full form.

This closes #117
